### PR TITLE
Trim whitespaces from option element label

### DIFF
--- a/src/SelectraElement.js
+++ b/src/SelectraElement.js
@@ -301,7 +301,7 @@ class SelectraElement {
       if (optionElement.tagName === 'OPTION') {
         options.push({
           value: optionElement.value,
-          label: unescape(optionElement.innerHTML),
+          label: unescape(optionElement.innerHTML.trim()),
           selected: this.multiple ? optionElement.selected : this.element.value === optionElement.value,
           disabled: !!optionElement.disabled
         })


### PR DESCRIPTION
When you have the following HTML code:
```
<select name="tz" class="my-select">
<option value="UTC">
			Universal Time, Coordinated (UTC)		
</option>
<option value="Africa/Abidjan" selected>
					Africa/Abidjan				
</option>
</select>
```
then it renders with the white spaces, like
![image](https://user-images.githubusercontent.com/251072/139682371-99b8a4d3-9d52-4ec1-b503-56ee763bc0e7.png)

Trimming white spaces, solves the issue.