### PR TITLE
improve multi select

### DIFF
--- a/src/SelectraElement.js
+++ b/src/SelectraElement.js
@@ -309,7 +309,10 @@ class SelectraElement {
       // Remove selected from all of the items
       Array.from(this.element.options).forEach((option) => {
         option.selected = false
-        this.optionsElement.querySelector('.selectra-option[data-value="' + value + '"]').dataset.selected = false
+        const optionElement = this.optionsElement.querySelector('.selectra-option[data-value="' + option.value + '"]')
+        if (optionElement) {
+          optionElement.dataset.selected = false
+        }
       })
 
       // Find value in currentValue
@@ -323,8 +326,14 @@ class SelectraElement {
 
       // Add selected for remaining items
       for (const value of currentValue) {
-        this.element.querySelector('option[value="' + value + '"]').selected = true
-        this.optionsElement.querySelector('.selectra-option[data-value="' + value + '"]').dataset.selected = true
+        const optionElement = this.element.querySelector('option[value="' + value + '"]')
+        if (optionElement) {
+          optionElement.selected = true
+        }
+        const selectraOptionElement = this.optionsElement.querySelector('.selectra-option[data-value="' + value + '"]')
+        if (selectraOptionElement) {
+          selectraOptionElement.dataset.selected = true
+        }
       }
     } else {
       // Check if option is disabled yes or no

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -242,3 +242,44 @@ describe('add option groups programmatically', () => {
     expect(document.querySelector('#test-select').val()).toStrictEqual(['option2', 'option4'])
   })
 })
+
+describe('multi-select option selection toggle', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <select id="test-select" multiple>
+        <option value="option1">Option 1</option>
+        <option value="option2">Option 2</option>
+        <option value="option3">Option 3</option>
+      </select>
+    `
+    createSelectra('#test-select')
+  })
+
+  test('click on option to toggle selection', () => {
+    document.querySelector('#test-select').dispatchEvent(new Event('mousedown'))
+    document.querySelector('.selectra-option[data-value="option2"]').dispatchEvent(new Event('mouseup'))
+    expect(Array.from(document.querySelector('#test-select').selectedOptions).map(option => option.value)).toContain('option2')
+
+    document.querySelector('.selectra-option[data-value="option2"]').dispatchEvent(new Event('mouseup'))
+    expect(Array.from(document.querySelector('#test-select').selectedOptions).map(option => option.value)).not.toContain('option2')
+  })
+
+  test('select multiple options and then deselect one', () => {
+    document.querySelector('#test-select').dispatchEvent(new Event('mousedown'))
+    document.querySelector('.selectra-option[data-value="option1"]').dispatchEvent(new Event('mouseup'))
+    document.querySelector('.selectra-option[data-value="option2"]').dispatchEvent(new Event('mouseup'))
+    expect(Array.from(document.querySelector('#test-select').selectedOptions).map(option => option.value)).toStrictEqual(['option1', 'option2'])
+
+    document.querySelector('.selectra-option[data-value="option1"]').dispatchEvent(new Event('mouseup'))
+    expect(Array.from(document.querySelector('#test-select').selectedOptions).map(option => option.value)).toStrictEqual(['option2'])
+  })
+
+  test('no option selected after deselecting all', () => {
+    document.querySelector('#test-select').dispatchEvent(new Event('mousedown'))
+    document.querySelector('.selectra-option[data-value="option1"]').dispatchEvent(new Event('mouseup'))
+    document.querySelector('.selectra-option[data-value="option2"]').dispatchEvent(new Event('mouseup'))
+    document.querySelector('.selectra-option[data-value="option1"]').dispatchEvent(new Event('mouseup'))
+    document.querySelector('.selectra-option[data-value="option2"]').dispatchEvent(new Event('mouseup'))
+    expect(Array.from(document.querySelector('#test-select').selectedOptions).map(option => option.value)).toStrictEqual([])
+  })
+})


### PR DESCRIPTION
This PR improves the multi-select functionality of the Selectra library by addressing an issue that caused an "Uncaught TypeError: Cannot read properties of null" error.

#### Changes Made
- Refactored the code to ensure that `optionElement` and `selectraOptionElement` are checked for `null` before accessing their properties.
- Improved the logic to handle selection and deselection of multiple options without causing errors.

#### Reason for Changes
Previously, the code would cause an "Uncaught TypeError" when attempting to access properties of a null element. This error occurred due to the line:
```javascript
this.optionsElement.querySelector('.selectra-option[data-value="' + value + '"]').dataset.selected = true
```
The new implementation ensures that elements are checked for existence before accessing their properties, preventing this error from occurring.

#### Testing
Added tests to verify the following scenarios:
1. Toggling the selection of a single option.
2. Selecting multiple options and then deselecting one of them.
3. Deselecting all options to ensure no option is selected.

These tests ensure the multi-select functionality works as expected without causing errors.

---
